### PR TITLE
Add printing stdout on error in bb_cmd

### DIFF
--- a/entrypoint.bb.clj
+++ b/entrypoint.bb.clj
@@ -119,6 +119,7 @@
       (let [msg (if (string/blank? err)
                   (format "failed to execute command [%s]: exit code [%d]" cmd exit)
                   err)]
+        (println out)
         (println msg)
         (system-exit! msg exit)))))
 


### PR DESCRIPTION
I'm using this action to run tests using babashka via bb_cmd with non-zero code meaning tests failure, but the output is written to stdout, so in this case there is no logs in Github Actions log. This PR adds printing stdout in the case of error in bb_cmd.